### PR TITLE
Add the ability to duplicate (or“fork”) an artboard

### DIFF
--- a/Duplicate/Duplicate Artboard Below.sketchplugin
+++ b/Duplicate/Duplicate Artboard Below.sketchplugin
@@ -1,0 +1,17 @@
+// Duplicate Artboard Below (shift command d)
+
+#import 'library/common.js'
+
+current_selection = selection[0];
+
+if (current_selection.className() == "MSArtboardGroup") {
+  var parent = current_selection;
+} else {
+  var parent = [current_selection parentGroup];
+}
+
+var copy = [parent duplicate];
+
+[[copy frame] addY:[[parent frame] height] + 100]
+
+[copy select:true byExpandingSelection:false]

--- a/Duplicate/Duplicate Artboard Right.sketchplugin
+++ b/Duplicate/Duplicate Artboard Right.sketchplugin
@@ -1,0 +1,17 @@
+// Duplicate Artboard Right (shift command f)
+
+#import 'library/common.js'
+
+current_selection = selection[0];
+
+if (current_selection.className() == "MSArtboardGroup") {
+  var parent = current_selection;
+} else {
+  var parent = [current_selection parentGroup];
+}
+
+var copy = [parent duplicate];
+
+[[copy frame] addX:[[parent frame] width] + 100]
+
+[copy select:true byExpandingSelection:false]


### PR DESCRIPTION
I find these shortcuts really useful when I want to quick duplicate an artboard to try out a few variations.

![screen shot 2014-05-15 at 12 49 55 am](https://cloud.githubusercontent.com/assets/438160/2978974/79bff80e-dbc2-11e3-90b1-123b4cfbe7fe.png)
