### PR TITLE
Use Mocca pointer for out-argument

### DIFF
--- a/library/sandbox.js
+++ b/library/sandbox.js
@@ -147,10 +147,10 @@ var AppSandboxFileAccess = {
     if (bookmarkData) {
       log("Bookmark data found")
       // resolve the bookmark data into an NSURL object that will allow us to use the file
-      var bookmarkDataIsStale;
-      allowedUrl = [NSURL URLByResolvingBookmarkData:bookmarkData options:NSURLBookmarkResolutionWithSecurityScope|NSURLBookmarkResolutionWithoutUI relativeToURL:nil bookmarkDataIsStale:bookmarkDataIsStale error:null];
+      var bookmarkDataIsStalePtr = MOPointer.alloc().init();
+      allowedUrl = [NSURL URLByResolvingBookmarkData:bookmarkData options:NSURLBookmarkResolutionWithSecurityScope|NSURLBookmarkResolutionWithoutUI relativeToURL:nil bookmarkDataIsStale:bookmarkDataIsStalePtr error:null];
       // if the bookmark data is stale, we'll create new bookmark data further down
-      if (bookmarkDataIsStale) {
+      if (bookmarkDataIsStalePtr.value()) {
         bookmarkData = nil;
       }
     } else {


### PR DESCRIPTION
I had issues making use of the sandbox library functions in my own plugins, and found that it was failing on this line (in the new CocoaScript version of Sketch). Looks like this is a solid way of using pointers within CocoaScript...
