### PR TITLE
Fix and refactor Text commands

### DIFF
--- a/Sketch Commands.sketchplugin/Contents/Sketch/Text/Case Sentence case.cocoascript
+++ b/Sketch Commands.sketchplugin/Contents/Sketch/Text/Case Sentence case.cocoascript
@@ -1,32 +1,23 @@
 var onRun = function(context) {
   var selection = context.selection,
-      SentenceBoundary = "."
+      selectionCount = [selection count]
 
-  SentenceCase = function(txt){
+  function sentenceCase(string){
+    var sentenceRegExp = /(^|\.\s+)([a-z])/g
 
-    var arr = txt.split(SentenceBoundary),
-        txt_lc = txt.toLowerCase(),
-        txt_sc = txt_lc;
-
-    for (var i = 0; i < arr.length; i++) {
-      var sentence = arr[i].trim(),
-          sentence_lc = sentence.toLowerCase(),
-          sentence_uc = sentence.toUpperCase(),
-          sentence_sc;
-
-      sentence_sc = sentence_uc.slice(0,1) + sentence_lc.slice(1)
-      txt_sc = txt_sc.replace(sentence_lc,sentence_sc)
-    }
-
-    return txt_sc;
+    return string
+      .toLowerCase()
+      .replace(sentenceRegExp, function sentenceCaseReplacer(match, _, letter) {
+        return match.replace(letter, letter.toUpperCase())
+      })
   }
 
-  for (var i = 0; i < [selection count]; i++) {
-    var s = [selection objectAtIndex:i]
+  for (var i = 0; i < selectionCount; i++) {
+    var layer = [selection objectAtIndex:i]
 
-    if([s class] === MSTextLayer){
-      var new_text = SentenceCase([s stringValue]);
-      [s setStringValue:new_text]
+    if([layer class] === MSTextLayer){
+      var sentenceCaseString = sentenceCase([layer stringValue]);
+      [layer replaceTextPreservingAttributeRanges:sentenceCaseString]
     }
   }
 }

--- a/Sketch Commands.sketchplugin/Contents/Sketch/Text/Case Title Case.cocoascript
+++ b/Sketch Commands.sketchplugin/Contents/Sketch/Text/Case Title Case.cocoascript
@@ -1,36 +1,23 @@
 var onRun = function(context) {
-  var selection = context.selection
+  var selection = context.selection,
+      selectionCount = [selection count]
 
-  var WHITESPACE = /\s/,
-      BAD_CHARS = /(\,|\.|\+|\;|\:)/
+  function titleCase(string){
+    var titleRegExp = /\b([a-z])[A-Za-z]*\b/g
 
-  TitleCase = function(txt){
-
-    var arr = txt.split(WHITESPACE),
-        txt_lc = txt.toLowerCase(),
-        txt_tc = txt_lc;
-
-    for (var i = 0; i < arr.length; i++) {
-      var word = arr[i].replace(BAD_CHARS,''),
-          word_lc = word.toLowerCase(),
-          word_uc = word.toUpperCase(),
-          word_tc;
-
-      word_tc = word_uc.slice(0,1) + word_lc.slice(1)
-
-      var match = RegExp("\\b" + word_lc + "\\b")
-      txt_tc = txt_tc.replace(match,word_tc)
-    }
-
-    return txt_tc;
+    return string
+      .toLowerCase()
+      .replace(titleRegExp, function titleCaseReplacer(match, letter) {
+        return letter.toUpperCase() + match.substr(1)
+      })
   }
 
-  for (var i = 0; i < [selection count]; i++) {
-    var s = [selection objectAtIndex:i]
+  for (var i = 0; i < selectionCount; i++) {
+    var layer = [selection objectAtIndex:i]
 
-    if([s class] === MSTextLayer){
-      var new_text = TitleCase([s stringValue]);
-      [s setStringValue:new_text]
+    if([layer class] === MSTextLayer){
+      var sentenceCaseString = titleCase([layer stringValue]);
+      [layer replaceTextPreservingAttributeRanges:sentenceCaseString]
     }
   }
 }

--- a/Sketch Commands.sketchplugin/Contents/Sketch/Text/Case UPPERCASE.cocoascript
+++ b/Sketch Commands.sketchplugin/Contents/Sketch/Text/Case UPPERCASE.cocoascript
@@ -2,11 +2,10 @@ var onRun = function(context) {
   var selection = context.selection
 
   for (var i = 0; i < [selection count]; i++) {
-    var s = [selection objectAtIndex:i]
+    var layer = [selection objectAtIndex:i]
 
-    if([s class] === MSTextLayer){
-      var new_text = [s stringValue].toUpperCase();
-      [s setStringValue:new_text]
+    if([layer class] === MSTextLayer){
+      [layer makeUppercase:nil]
     }
   }
 }

--- a/Sketch Commands.sketchplugin/Contents/Sketch/Text/Case lowercase.cocoascript
+++ b/Sketch Commands.sketchplugin/Contents/Sketch/Text/Case lowercase.cocoascript
@@ -2,11 +2,10 @@ var onRun = function(context) {
   var selection = context.selection
 
   for (var i = 0; i < [selection count]; i++) {
-    var s = [selection objectAtIndex:i]
+    var layer = [selection objectAtIndex:i]
 
-    if([s class] === MSTextLayer){
-      var new_text = [s stringValue].toLowerCase();
-      [s setStringValue:new_text]
+    if([layer class] === MSTextLayer){
+      [layer makeLowercase:nil]
     }
   }
 }


### PR DESCRIPTION
- Improve performance extracting `[selection count]` from `for`loop condition
- Use regular expressions to reduce some lines of code and improve legibility
- Replace deprecated `setStringValue` by `replaceTextPreservingAttributeRanges`
- Use when possible `makeUppercase` and `makeLowercase` methods